### PR TITLE
Fix compiler warning.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -487,7 +487,8 @@ impl<'a> DepGraphMut<'a> {
         {
             Some(edge) => {
                 let head = edge.source().index();
-                let weight = self.inner.remove_edge(edge.id());
+                let edge_id = edge.id();
+                let weight = self.inner.remove_edge(edge_id);
                 Some(DepTriple::new(head, weight.unwrap().1, dependent))
             }
             None => None,


### PR DESCRIPTION
Fixes a compiler warning.

https://github.com/rust-lang/rust/issues/59159

```
warning: cannot borrow `*self.inner` as mutable because it is also borrowed as immutable
   --> src/graph.rs:491:30
    |
483 |           match self
    |  _______________-
484 | |             .inner
    | |__________________- immutable borrow occurs here
...
491 |                   let weight = self.inner.remove_edge(edge.id());
    |                                ^^^^^^^^^^             ---- immutable borrow later used here
    |                                |
    |                                mutable borrow occurs here
    |
    = note: #[warn(mutable_borrow_reservation_conflict)] on by default
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
```